### PR TITLE
fix: レイアウトとマウスホバーの表示問題を修正

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -266,7 +266,7 @@ export class Game {
         this.previewElement.className = canPlace ? 'building-preview' : 'building-preview invalid';
 
         // プレビューの位置とサイズを設定
-        const cellSize = 32; // GAME_CONFIG.CELL_SIZEと同じ値
+        const cellSize = GAME_CONFIG.CELL_SIZE;
         const rect = this.canvas.getBoundingClientRect();
         const canvasX = mouseX - rect.left;
         const canvasY = mouseY - rect.top;

--- a/style.css
+++ b/style.css
@@ -123,7 +123,7 @@ body {
 .game-area {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     background: rgba(44, 62, 80, 0.3);
     border-radius: 20px;


### PR DESCRIPTION
## 概要
ゲーム画面のレイアウトとマウスホバー時の表示問題を修正しました。

## 変更内容

### 1. ゲーム画面の上寄せ配置
- **問題**: 縦長のブラウザでゲーム画面が縦方向に中央寄せされ、上部に余計な空白が表示されていた
- **修正**: `.game-area`の`justify-content`を`center`から`flex-start`に変更
- **結果**: ゲーム画面が上部に配置され、余白が解消

### 2. マウスホバープレビューのサイズ修正
- **問題**: マウスオーバー時の半透明プレビューがグリッドのマス目より大きく表示されていた
- **修正**: ハードコーディングされていた`cellSize = 32`を`GAME_CONFIG.CELL_SIZE`（26px）に変更
- **結果**: プレビューとグリッドのサイズが完全に一致

## テスト項目
- [x] 縦長ブラウザでゲーム画面が上寄せされることを確認
- [x] マウスホバー時のプレビューがグリッドと同じサイズで表示されることを確認
- [x] 建物の設置・削除が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)