### PR TITLE
✨ feat: ベストスコアクリア機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                 <section class="max-efficiency-section">
                     <div class="section-header">
                         <h3 class="section-title">🏆 最大効率記録</h3>
-                        <button type="button" class="clear-best-score-btn" id="clear-best-score-btn" title="ベストスコアをクリア">
+                        <button type="button" class="clear-best-score-btn" id="clear-best-score-btn" title="ベストスコアをクリア" aria-label="ベストスコアをクリア">
                             <span class="clear-icon">🗑️</span>
                             <span class="clear-text">クリア</span>
                         </button>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,13 @@
 
                 <!-- 最大効率記録 -->
                 <section class="max-efficiency-section">
-                    <h3 class="section-title">🏆 最大効率記録</h3>
+                    <div class="section-header">
+                        <h3 class="section-title">🏆 最大効率記録</h3>
+                        <button class="clear-best-score-btn" id="clear-best-score-btn" title="ベストスコアをクリア">
+                            <span class="clear-icon">🗑️</span>
+                            <span class="clear-text">クリア</span>
+                        </button>
+                    </div>
                     <div class="max-efficiency-container">
                         <div class="max-efficiency-card">
                             <div class="max-efficiency-icon">🎖️</div>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                 <section class="max-efficiency-section">
                     <div class="section-header">
                         <h3 class="section-title">🏆 最大効率記録</h3>
-                        <button class="clear-best-score-btn" id="clear-best-score-btn" title="ベストスコアをクリア">
+                        <button type="button" class="clear-best-score-btn" id="clear-best-score-btn" title="ベストスコアをクリア">
                             <span class="clear-icon">🗑️</span>
                             <span class="clear-text">クリア</span>
                         </button>

--- a/src/game.js
+++ b/src/game.js
@@ -154,7 +154,7 @@ export class Game {
     clearBestScore() {
         if (confirm('ベストスコアをクリアしますか？\nゲーム画面もリセットされます。')) {
             // ベストスコアをクリア
-            localStorage.removeItem('maxBeltEfficiency');
+            localStorage.removeItem(MAX_EFFICIENCY_KEY);
             this.maxEfficiency = 0;
             
             // ゲームもリセット（確認なし）

--- a/src/game.js
+++ b/src/game.js
@@ -5,6 +5,9 @@ import { ItemManager } from './items.js';
 import { Renderer } from './renderer.js';
 import { EfficiencyChart } from './efficiency-chart.js';
 
+// LocalStorageキー
+const MAX_EFFICIENCY_KEY = 'maxBeltEfficiency';
+
 /**
  * メインゲームクラス
  */
@@ -74,7 +77,7 @@ export class Game {
      * @returns {Object} 最大効率データ
      */
     loadMaxEfficiency() {
-        const saved = localStorage.getItem('maxBeltEfficiency');
+        const saved = localStorage.getItem(MAX_EFFICIENCY_KEY);
         if (saved) {
             return JSON.parse(saved);
         }
@@ -104,7 +107,7 @@ export class Game {
             buildingStats: buildingStats
         };
         this.stats.maxBeltEfficiency = data;
-        localStorage.setItem('maxBeltEfficiency', JSON.stringify(data));
+        localStorage.setItem(MAX_EFFICIENCY_KEY, JSON.stringify(data));
     }
     
     /**

--- a/src/game.js
+++ b/src/game.js
@@ -141,6 +141,45 @@ export class Game {
     }
 
     /**
+     * ベストスコアをクリア
+     */
+    clearBestScore() {
+        if (confirm('ベストスコアをクリアしますか？\nゲーム画面もリセットされます。')) {
+            // ベストスコアをクリア
+            localStorage.removeItem('maxBeltEfficiency');
+            this.maxEfficiency = 0;
+            
+            // ゲームもリセット（確認なし）
+            this.buildingManager.clear();
+            this.itemManager.clear();
+            
+            // 生産カウントをリセット
+            Object.keys(this.totalProduced).forEach(key => {
+                this.totalProduced[key] = 0;
+            });
+            Object.keys(this.resourceCounts).forEach(key => {
+                this.resourceCounts[key] = 0;
+            });
+            
+            // 統計をリセット
+            Object.keys(this.stats.resourceRates).forEach(key => {
+                this.stats.resourceRates[key] = 0;
+                this.stats.lastResourceCounts[key] = 0;
+            });
+            this.stats.productionHistory = [];
+            this.stats.efficiencyHistory = [];
+            
+            // グラフをクリア
+            this.efficiencyChart.data = new Array(this.efficiencyChart.maxDataPoints).fill(0);
+            this.efficiencyChart.draw();
+            
+            // UIを更新
+            this.updateDisplay();
+            this.updateMaxEfficiencyDisplay();
+        }
+    }
+
+    /**
      * イベントリスナー設定
      */
     setupEventListeners() {
@@ -155,6 +194,9 @@ export class Game {
         
         // リセットボタン
         document.getElementById('reset-btn')?.addEventListener('click', () => this.resetGame());
+        
+        // ベストスコアクリアボタン
+        document.getElementById('clear-best-score-btn')?.addEventListener('click', () => this.clearBestScore());
         
         // キャンバスイベント
         this.canvas.addEventListener('click', (e) => this.handleClick(e));

--- a/src/game.js
+++ b/src/game.js
@@ -108,6 +108,19 @@ export class Game {
     }
     
     /**
+     * カウントをリセットするヘルパー関数
+     */
+    resetCounts() {
+        // 生産カウントをリセット
+        Object.keys(this.totalProduced).forEach(key => {
+            this.totalProduced[key] = 0;
+        });
+        Object.keys(this.resourceCounts).forEach(key => {
+            this.resourceCounts[key] = 0;
+        });
+    }
+
+    /**
      * ゲームをリセット（建物を全て削除、記録もリセット）
      */
     resetGame() {
@@ -116,13 +129,8 @@ export class Game {
             this.buildingManager.clear();
             this.itemManager.clear();
             
-            // 生産カウントをリセット
-            Object.keys(this.totalProduced).forEach(key => {
-                this.totalProduced[key] = 0;
-            });
-            Object.keys(this.resourceCounts).forEach(key => {
-                this.resourceCounts[key] = 0;
-            });
+            // カウントをリセット
+            this.resetCounts();
             
             // 統計をリセット
             Object.keys(this.stats.resourceRates).forEach(key => {
@@ -153,13 +161,8 @@ export class Game {
             this.buildingManager.clear();
             this.itemManager.clear();
             
-            // 生産カウントをリセット
-            Object.keys(this.totalProduced).forEach(key => {
-                this.totalProduced[key] = 0;
-            });
-            Object.keys(this.resourceCounts).forEach(key => {
-                this.resourceCounts[key] = 0;
-            });
+            // カウントをリセット
+            this.resetCounts();
             
             // 統計をリセット
             Object.keys(this.stats.resourceRates).forEach(key => {

--- a/style.css
+++ b/style.css
@@ -539,6 +539,52 @@ body {
     line-height: 1.3;
 }
 
+/* セクションヘッダー（タイトルとボタン） */
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
+.section-header .section-title {
+    margin: 0;
+}
+
+/* ベストスコアクリアボタン */
+.clear-best-score-btn {
+    background: rgba(231, 76, 60, 0.7);
+    border: 1px solid rgba(231, 76, 60, 0.5);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    font-size: 0.75rem;
+    color: white;
+}
+
+.clear-best-score-btn:hover {
+    background: rgba(231, 76, 60, 0.9);
+    border-color: rgba(231, 76, 60, 0.7);
+    box-shadow: 0 1px 4px rgba(231, 76, 60, 0.3);
+}
+
+.clear-best-score-btn:active {
+    background: rgba(231, 76, 60, 1);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.clear-best-score-btn .clear-icon {
+    font-size: 0.85rem;
+}
+
+.clear-best-score-btn .clear-text {
+    font-weight: 500;
+}
+
 /* ===== ガイドセクション ===== */
 .guide-content {
     display: flex;


### PR DESCRIPTION
## 概要
ユーザーが任意のタイミングでベストスコアをクリアできる機能を追加しました。

## 実装内容

### 1. UIの追加
- 「🏆 最大効率記録」セクションタイトルの右側に「🗑️ クリア」ボタンを配置
- ボタンはセクションカードに被らないよう、タイトルと同じ行に配置

### 2. 機能の実装
- `clearBestScore()` メソッドを`Game`クラスに追加
- 確認ダイアログ：「ベストスコアをクリアしますか？ゲーム画面もリセットされます。」
- OKを選択すると：
  - LocalStorageから`maxBeltEfficiency`を削除
  - ベストスコアを0にリセット
  - ゲーム画面も同時にリセット（建物、アイテム、統計を全てクリア）

### 3. スタイリング
- 小さめのボタンサイズ（padding: 0.25rem 0.5rem）
- 赤色の背景で削除操作であることを明示
- ホバー時の視覚的フィードバック

## スクリーンショット
- Before: クリアボタンがベストスコアカードに被っていた
- After: セクションタイトルの横にすっきりと配置

## テスト項目
- ✅ クリアボタンのクリックで確認ダイアログが表示される
- ✅ キャンセルした場合は何も起きない
- ✅ OKした場合、ベストスコアがクリアされる
- ✅ ゲーム画面も同時にリセットされる
- ✅ ページをリロードしてもベストスコアがクリアされたままである

## 影響範囲
- 既存の機能には影響なし
- ユーザーの利便性が向上

🤖 Generated with [Claude Code](https://claude.ai/code)